### PR TITLE
validating categories

### DIFF
--- a/.github/workflows/validate-category-create-comment.yaml
+++ b/.github/workflows/validate-category-create-comment.yaml
@@ -1,0 +1,65 @@
+name: Category Validation - Comment on the pull request
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Validate Categories on PR"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        id: download-artifact
+        with:
+          script: |
+            try {
+              var artifacts = await github.actions.listWorkflowRunArtifacts({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 run_id: ${{github.event.workflow_run.id }},
+              });
+              var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == "category_validation"
+              })[0];
+              if(matchArtifact) {
+                var download = await github.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchArtifact.id,
+                 archive_format: 'zip',
+                });
+                var fs = require('fs');
+                fs.writeFileSync('${{github.workspace}}/category_validation.zip', Buffer.from(download.data));
+                console.log("::set-output name=artifact-exists::true")
+              }
+            } catch (error) {
+                  console.error(error);
+            }
+            
+      - run: unzip category_validation.zip
+        if: ${{steps.download-artifact.outputs.artifact-exists == 'true' }}
+
+      - name: 'Comment on PR'
+        if: ${{steps.download-artifact.outputs.artifact-exists == 'true' }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./issue_number'));
+            console.log(issue_number)
+            var output = fs.readFileSync('./output', 'utf8')
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: output
+            });

--- a/.github/workflows/validate-category-on-pr.yaml
+++ b/.github/workflows/validate-category-on-pr.yaml
@@ -1,0 +1,61 @@
+name: Validate Categories on PR
+
+# read-only repo token
+# no access to secrets
+on:
+  pull_request:
+
+jobs:
+  validate-categories:
+    runs-on: ubuntu-latest
+
+    steps:        
+      - uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        with:
+          ruby-version: 2.7.2
+
+      - name: Validate Categories
+        id: validate-categories
+        run: |
+          ruby validate.rb
+        working-directory: ./script/validate-categories
+      - name: Format Comment
+        id: comment-format
+        shell: bash
+        run: |
+          validation_content_length=`echo "${{join(steps.validate-categories.outputs.*,',')}}" | wc -c`
+          if [ $validation_content_length -le 1 ]; then
+            echo "no output from validate-category"
+            exit 0;
+          fi
+          allowed_categories=$(cat ./script/validate-categories/settings.json | ruby -r json -e 'puts JSON.parse(STDIN.read)["allowed_categories"]')
+          MY_STRING=$(cat <<-EOF
+          :heavy_exclamation_mark: :heavy_exclamation_mark: The following templates did not contain a recognised category. Please note that setting categories in the properties.json of the template will result in better visibility and recommendation.
+          The recognised categories are:
+          $allowed_categories
+          |Workflow Template Id|
+          |:----:  |
+          EOF
+          )
+          MY_STRING="${MY_STRING//'%'/'%25'}"
+          MY_STRING="${MY_STRING//$'\n'/'%0A'}"
+          MY_STRING="${MY_STRING//$'\r'/'%0D'}"
+          MY_STRING="${MY_STRING}%0A${{join(steps.validate-categories.outputs.*, '%0A')}}"
+          echo "::set-output name=content::$MY_STRING"
+          
+
+      - name: Save Validation Output 
+        if: ${{steps.comment-format.outputs.content && steps.comment-format.outputs.content != '' }}
+        run: |
+          mkdir -p ./category_validation
+          echo "${{ steps.comment-format.outputs.content }}" > ./category_validation/output
+          echo ${{ github.event.number }} > ./category_validation/issue_number
+
+      - uses: actions/upload-artifact@v2
+        if: ${{steps.comment-format.outputs.content && steps.comment-format.outputs.content != '' }}
+        with:
+          name: category_validation
+          path: category_validation/

--- a/script/validate-categories/settings.json
+++ b/script/validate-categories/settings.json
@@ -1,0 +1,13 @@
+{
+    "folders": [
+      "../../ci",
+      "../../automation",
+      "../../deployments"
+    ],
+    "allowed_categories" : [
+      "Continuous-Integration",
+      "Deployment",
+      "Code Scanning",
+      "Automation"
+    ]
+  }

--- a/script/validate-categories/validate.rb
+++ b/script/validate-categories/validate.rb
@@ -1,0 +1,37 @@
+require 'json'
+
+settings = JSON.parse(File.read('./settings.json'))
+folders = settings['folders']
+@allowed_categories = settings['allowed_categories']
+
+def validateCategories(categories)
+    return categories.nil? || (categories.is_a?(Array) && ! categories.select{|l| @allowed_categories.detect{|p| p.casecmp(l) == 0 } }.empty? )
+end
+
+result = []
+for folder in folders
+    files = Dir.entries(folder).select {|entry| File.file?(File.join(folder, entry)) && (File.extname(entry) == ".yaml" || File.extname(entry) == ".yml") }
+    for file in files
+        workflowId = File.basename(file,  File.extname(file))
+        raiseError = false
+        propertiesPath = folder + "/" + "properties/" + workflowId+".properties.json"
+        if(File.exist?(propertiesPath)) 
+            begin
+                properties = JSON.parse(File.read(propertiesPath))
+                raiseError = ! validateCategories(properties['categories'])
+            rescue JSON::ParserError
+                raiseError = true
+            end
+        else
+            raiseError = true 
+        end
+        if raiseError
+            result.push({"id" => workflowId})
+        end
+    end
+end
+if result.length > 0
+    result.each do |r|
+        puts "::set-output name=unrecognised-categories-#{r["id"]}:: \|#{r["id"]}\|"
+    end
+end


### PR DESCRIPTION
<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.

**For _CI_ workflows, the workflow:**

- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [ ] `name`: Name of the Code Scanning integration.
  - [ ] `organization`: Name of the organization producing the Code Scanning integration.
  - [ ] `description`: Short description of the Code Scanning integration.
  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [ ] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Automation and CI workflows cannot be dependent on a paid service or product.
